### PR TITLE
remove gem role, because installed gem not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ $ chzh
   - 詳細は公式のREADMEを参照
 - key-bindingsを `vi` に変更
 - [Customizing Your Prezto Prompt - Mike Buss](https://mikebuss.com/2014/04/07/customizing-prezto/)を参考にthemeを好きなものに変更する
+
+### Ruby Gems
+
+[Ansible gem module](https://docs.ansible.com/ansible/2.5/modules/gem_module.html)を利用して、インストールできそうだったがインストールしたはずのgemコマンドが利用できない問題があったためひとまず未対応。詳細は[このPull Request](https://github.com/kojoma/my-settings/pull/14)に記述している。

--- a/local.yml
+++ b/local.yml
@@ -6,7 +6,6 @@
     - homebrew
     - homebrew-cask
     - mas
-    - gem
     - setup-git
     - setup-ssh
     - setup-vim

--- a/roles/gem/tasks/main.yml
+++ b/roles/gem/tasks/main.yml
@@ -1,8 +1,0 @@
----
-
-- name: Install gem Packages
-  gem:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - cocoapods


### PR DESCRIPTION
gem roleを使ってインストールしたはずのgemが、コマンドラインで利用できなかった。
https://docs.ansible.com/ansible/2.5/modules/gem_module.html
を参考に
- become: yes
- user_install: no
などを試したが、解決できなかった。

正常に動作しないものを残しておくのも困るのでroleごと削除する。
ひとまずgemは手動でインストールする方針にする。