### PR TITLE
Remove Dash app

### DIFF
--- a/roles/homebrew-cask/tasks/main.yml
+++ b/roles/homebrew-cask/tasks/main.yml
@@ -13,7 +13,6 @@
     - android-studio
     - android-file-transfer
     - appcleaner
-    - dash
     - docker
     - firefox
     - google-chrome


### PR DESCRIPTION
- Dash app uses for snippets
- But snippets are move to Alfred