### PR TITLE
Suppress python_interpreter warnings

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+interpreter_python=/usr/bin/python


### PR DESCRIPTION
For suppress below warning.

```
[WARNING]: Platform darwin on host localhost is using the discovered Python interpreter at /usr/bin/python, but future installation of another Python interpreter could change
this. See https://docs.ansible.com/ansible/2.8/reference_appendices/interpreter_discovery.html for more information.
```