### PR TITLE
Remove Google japanese ime

### DIFF
--- a/roles/homebrew_cask/tasks/main.yml
+++ b/roles/homebrew_cask/tasks/main.yml
@@ -27,7 +27,6 @@
     - docker
     - font-cica
     - google-chrome
-    - google-japanese-ime
     - inkdrop
     - intellij-idea
     - iterm2


### PR DESCRIPTION
No longer used, I'll use Apple default ime.