### PR TITLE
Install PHP

### DIFF
--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -13,6 +13,7 @@
       - hugo
       - jq
       - peco
+      - php
       - tig
       - tree
       - vim


### PR DESCRIPTION
After macOS Monterey, no bundle PHP. So install with Homebrew.