### PR TITLE
Change install directory

### DIFF
--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -1,13 +1,10 @@
 # Provisioning Mac
 
-![Ansible lint](https://github.com/kojoma/my-settings/workflows/Ansible%20lint/badge.svg)
-
 ## Prepare install
 
 ```
 $ cd ~/
-$ mkdir Works
-$ cd Works
+$ mkdir -p Works/github.com/kojoma && "$_"
 
 # gitコマンドを実行するためにはコマンドラインツールをインストールする必要がある
 $ xcode-select --install


### PR DESCRIPTION
1. 初回は雑に適当なディレクトリで clone してインストール
1. 整ってきたら ghq 準拠のディレクトリで git clone し直す

ということをやると 1 で作ったシンボリックリンクが作り直しになって面倒なので、最初から ghq 準拠のディレクトリに clone するように変更した。